### PR TITLE
added gamepad

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -277,6 +277,7 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+[Win32: Colour Rumble Pad]
 [Jess Tech Colour Rumble Pad]
 plugged = True
 plugin = 1


### PR DESCRIPTION
Different names on Linux and Windows

saitek p580 rumble pad (name in windows device manager)
Colour Rumble Pad (name detected by mupen64 on windows 8)
Jess Technology Colour Rumble Pad (name on Linux lsusb)

Tested on windows 8 and Ubuntu 12.04
