### PR TITLE
fixing ipega gamepad controllers

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -275,6 +275,29 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+[ipega media gamepad controller]
+plugged = True
+plugin = 2
+mouse = False
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(11)
+Z Trig = button(6)
+B Button = button(3)
+A Button = button(0)
+C Button R = axis(2+)
+C Button L = axis(2-)
+C Button D = axis(3+)
+C Button U = axis(3-)
+R Trig = axis(4+)
+L Trig = axis(5+)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 [Jess Tech Dual Analog Pad]
 plugged = True
 plugin = 2


### PR DESCRIPTION
@richard42 I noticed that one of my messages on the mailing list didn’t go through and created a slight misunderstanding. (In commit 930efa4731)

I fixed this here – there are 2 ipega controllers (one normal, one media) with a slightly different configuration.

Thanks!
