### PR TITLE
add auto-configuration for ACRUX Gamepads

### DIFF
--- a/README
+++ b/README
@@ -43,11 +43,33 @@ The bottom shoulder buttons select the memory pack or rumble pak.
 I came up with what I see as one of the few decent configurations (SSB aside) since it allows access to everything but the dpad.
 A is L1, B is R1, Z is L2, R is R2, L is select. C buttons are the four buttons, and the dpad acts as the joystick. Not the most orthodox, but it works well.
 
-4. Microsoft X-Box 360 pad:
-C button U (up) and C button R (right) are assigned to the Y and B buttons.
-All 4 C buttons are assigned to the U and V axis (including the already configured up and right C buttons).
-The Z button has been assigned to the left trigger and switching the rumble on and off can be done with the right trigger.
-Because there are no other buttons left I decided to use the button click behavior of the left joystick to switch Mempak on and off.
+4. Microsoft Xbox 360 controller and clones:
+
+N64          -> Xbox 360:
+
+analog stick -> left stick
+digital pad  -> directional pad
+R            -> right bumper, right trigger
+L            -> left bumper
+Z            -> left trigger
+A            -> A
+B            -> X
+start        -> start
+C buttons    -> right stick
+C left       -> Y (additionally to right stick)
+C down       -> B (additionally to right stick)
+
+mempak       -> none for now
+rumblepak    -> none for now
+
+As discussed in issue #478 Xbox 360 controllers should follow the above
+mapping convention. If you want to add a Xbox 360 controller clone please
+stick to it. As your clone might has different button naming, you can find
+Xbox 360 controller button names at
+https://en.wikipedia.org/wiki/File:360_controller.svg
+
+Keys that are still unbound are back (aka. select) and left/right stick button
+clicks. Those might be used for mempack and rumblepak toggles.
 
 5. MP-8866 Dual USB Joypad:
 This is a USB adapter for PlayStation controllers (2).

--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -586,6 +586,33 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+; ACRUX Gamepad (USB ID: 1a34:0802), a Xbox 360 controller clone aviable under
+; various brands (e.g. techsolo TG-30)
+[USB GAMEPAD 8116]
+plugged = True
+plugin = 2
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+Z Trig = axis(4-)
+B Button = button(2)
+A Button = button(0)
+C Button R = axis(3+)
+C Button L = axis(3-) button(3)
+C Button D = axis(2+) button(1)
+C Button U = axis(2-)
+R Trig = button(5) axis(4+)
+L Trig = button(4)
+Mempak switch = 
+Rumblepak switch = 
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 [XInput: Microsoft X-Box 360 pad]
 [XInput: Controller (XBOX 360 For Windows)]
 [XInput: XBOX 360 For Windows (Controller)]


### PR DESCRIPTION
Add auto-configuration for ACRUX Gamepads (USB ID: 1a34:080) a Xbox 360
controller clone sold under various brands and clarify mapping description
for Xbox 360 controllers and clones in README.
