### PR TITLE
switch order of ipega controllers so the media one works as well

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -252,29 +252,6 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
-[ipega gamepad controller]
-plugged = True
-plugin = 2
-mouse = False
-DPad R = hat(0 Right)
-DPad L = hat(0 Left)
-DPad D = hat(0 Down)
-DPad U = hat(0 Up)
-Start = button(9)
-Z Trig = button(2)
-B Button = button(0)
-A Button = button(1)
-C Button R = axis(2+)
-C Button L = axis(2-)
-C Button D = axis(3+)
-C Button U = axis(3-)
-R Trig = button(5)
-L Trig = button(4)
-Mempak switch =
-Rumblepak switch =
-X Axis = axis(0-,0+)
-Y Axis = axis(1-,1+)
-
 [ipega media gamepad controller]
 plugged = True
 plugin = 2
@@ -293,6 +270,29 @@ C Button D = axis(3+)
 C Button U = axis(3-)
 R Trig = axis(4+)
 L Trig = axis(5+)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
+[ipega gamepad controller]
+plugged = True
+plugin = 2
+mouse = False
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+Z Trig = button(2)
+B Button = button(0)
+A Button = button(1)
+C Button R = axis(2+)
+C Button L = axis(2-)
+C Button D = axis(3+)
+C Button U = axis(3-)
+R Trig = button(5)
+L Trig = button(4)
 Mempak switch =
 Rumblepak switch =
 X Axis = axis(0-,0+)


### PR DESCRIPTION
I noticed that with the current config, the ipega _media_ gamepad controller didn’t work. Simply switching them around to put the media one at the top makes it work, and keeps the other one working.

Please review @richard42 (this also might be an issue which should be fixed in the automatic SDL selection)
