### PR TITLE
To prevent undesirable return to centre of cursor while using touchpad.

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -625,8 +625,12 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
                 axis_val = 80;
             controller[Control].buttons.Y_AXIS = -axis_val;
             /* the mouse x/y values decay exponentially */
-            mousex_residual = (mousex_residual * 224) / 256;
-            mousey_residual = (mousey_residual * 224) / 256;
+            if (!myKeyState[SDLK_LSUPER]) /*So That FPS game can be easily played without cursor trying to return to 
+            origin (0,0). To do this press left Win.*/
+            {
+                mousex_residual = (mousex_residual * 224) / 256;
+                mousey_residual = (mousey_residual * 224) / 256;
+            }
         }
         else
         {


### PR DESCRIPTION
![problem_with_cursor](https://cloud.githubusercontent.com/assets/8034632/3442084/79f4808a-010e-11e4-8bd8-0c15473eec78.png)
....

While playing FPS game like Goldeneye, The World is not Enough etc with touchpad, the cursor/crosshair/crosswire tries to return to origin/centre thus preventing player to set it to target hence shoot it. Now this can be prevented by pressing Left Window Key, then moving cursor through touchpad.
