### PR TITLE
Check if the size calculation for config file failed

### DIFF
--- a/src/autoconfig.c
+++ b/src/autoconfig.c
@@ -212,6 +212,12 @@ int auto_set_defaults(int iDeviceIdx, const char *joySDLName)
     fseek(pfIn, 0L, SEEK_END);
     iniLength = ftell(pfIn);
     fseek(pfIn, 0L, SEEK_SET);
+    if (iniLength < 0) {
+        DebugMessage(M64MSG_ERROR, "Couldn't get size of config file '%s'", CfgFilePath);
+        fclose(pfIn);
+        return 0;
+    }
+
     pchIni = (char *) malloc(iniLength + 1);
     if (pchIni == NULL)
     {


### PR DESCRIPTION
This should fix the CID 38117 in Coverity.

Does anyone know how I can find the second bug? The overview page says that there should be two bugs but I can only see one under "Outstanding Defects"