### PR TITLE
added config for another wireless XBOX receiver

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -604,6 +604,31 @@ Rumblepak switch = button(11)
 Y Axis = axis(1-,1+)
 X Axis = axis(0-,0+)
 
+[Linux: Xbox 360 Wireless Receiver (XBOX)]
+plugged = True
+plugin = 2
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(7)
+Z Trig = axis(2+)
+B Button = button(2)
+A Button = button(0)
+C Button R = axis(3+)
+C Button L = axis(3-) button(3)
+C Button D = axis(4+) button(1)
+C Button U = axis(4-)
+R Trig = button(5) axis(5+)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 [Microsoft X-Box 360 pad]
 [Microsoft X-Box One pad]
 [Win32: Controller (XBOX 360 For Windows)]


### PR DESCRIPTION
I'm using this receiver: http://www.newegg.com/Product/Product.aspx?Item=9SIA0U008T5260
It identifies as 'Xbox 360 Wireless Receiver (XBOX)', and needed axes 3 and 4 switched from the normal xbox controller config, so I added it as a separate entry.