### PR TITLE
add config for Sony playstation 4 controller

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -871,7 +871,6 @@ Y Axis = axis(1-,1+)
 
 [PLAYSTATION(R)3 Controller]
 [Sony PLAYSTATION(R)3 Controller]
-[Sony Computer Entertainment Wireless Controller]
 [SHENGHIC 2009/0708ZXW-V1Inc. PLAYSTATION(R)3Conteroller]
 plugged = True
 plugin = 2
@@ -894,6 +893,31 @@ R Trig = button(11)
 L Trig = button(8)
 Mempak switch = 
 Rumblepak switch = 
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
+[Sony Computer Entertainment Wireless Controller]
+plugged = True
+plugin = 2
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+Z Trig = axis(3+)
+B Button = button(0)
+A Button = button(1)
+C Button R = axis(2+)
+C Button L = axis(2-)
+C Button D = axis(5+)
+C Button U = axis(5-)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 


### PR DESCRIPTION
This adds a configuration for the Sony Playstation 4 controller (Dualshock 4).

It appears that the name is the same as one of the possible names of the PS3 controller, thus I removed it from the PS3 config.