### PR TITLE
Add autoconfig support for Xbox One Wireless Controller (Dongle)

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -769,6 +769,7 @@ Y Axis = axis(1-,1+)
 [Xbox 360 Wireless Receiver]
 [Linux: Xbox Gamepad (userspace driver)]
 [Afterglow Gamepad for Xbox 360]
+[Controller (Xbox One For Windows)]
 plugged = True
 plugin = 2
 mouse = False


### PR DESCRIPTION
Add autoconfig support for Xbox One Wireless Dongle device is listed under [Controller (Xbox One For Windows)]