### PR TITLE
FIX Auto detection of PLAYSTATION(R)3 Controller on OSX

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -825,7 +825,6 @@ Y Axis = axis(1-,1+)
 
 # mappings for use with the TattieBogle driver under OSX, given in googlecode.com issue #630
 [OSX: Wireless 360 Controller]
-[OSX: Controller]
 plugged = True
 plugin = 2
 mouse = False


### PR DESCRIPTION
The PLAYSTATION(R)3 Controller was not configured correctly by default, it was configured as a 360 controller.