### PR TITLE
Don't set "plugin" as part of autoconfig

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -2,7 +2,6 @@
 
 [Keyboard]
 plugged = True
-plugin = 2
 mouse = False
 DPad R = key(100)
 DPad L = key(97)
@@ -25,7 +24,6 @@ Y Axis = key(273,274)
 
 [Austgame PS to USB convert cable]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -50,7 +48,6 @@ Y Axis = axis(1-,1+)
 
 [BDA Pro Ex]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -76,7 +73,6 @@ Y Axis = axis(1-,1+)
 ; Boom Smart Joy Converter
 [HID 6666:0667]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -101,7 +97,6 @@ Y Axis = axis(1-,1+)
 
 [Cyborg V.3 Rumble Pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -126,7 +121,6 @@ Y Axis = axis(1-,1+)
 
 [DragonRise Inc. Generic USB Joystick]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -152,7 +146,6 @@ Y Axis = axis(1-,1+)
 ; FuSa is a homebrew program which allows a PSP to be used as a gamepad
 [FuSa FuSa GamePad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -178,7 +171,6 @@ Y Axis = axis(1-,1+)
 ; "Super Joy Box 13" USB adaptor for a Gamecube controller
 [GameCube to USB box 1]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -203,7 +195,6 @@ Y Axis = axis(1-,1+)
 
 [Gasia Co.,Ltd PS(R) Gamepad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -230,7 +221,6 @@ Y Axis = axis(1-,1+)
 [GC/N64_USB]
 [GC/N64 to USB, v2.9]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -258,7 +248,6 @@ Y Axis = axis(1-,1+)
 [raphnet technologies N64 to USB]
 [raphnet technologies Dual N64 to USB]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -284,7 +273,6 @@ Y Axis = axis(1-,1+)
 ; Retrolink N64 USB clone 
 [Generic   USB  Joystick]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -309,7 +297,6 @@ X Axis = axis(0-,0+)
 
 [GreenAsia Inc. USB Joystick]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -334,7 +321,6 @@ Y Axis = axis(1-,1+)
 
 [GS gamepad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -359,7 +345,6 @@ Y Axis = axis(1-,1+)
 
 [ipega media gamepad controller]
 plugged = True
-plugin = 2
 mouse = False
 DPad R = hat(0 Right)
 DPad L = hat(0 Left)
@@ -382,7 +367,6 @@ Y Axis = axis(1-,1+)
 
 [ipega gamepad controller]
 plugged = True
-plugin = 2
 mouse = False
 DPad R = hat(0 Right)
 DPad L = hat(0 Left)
@@ -405,7 +389,6 @@ Y Axis = axis(1-,1+)
 
 [Jess Tech Dual Analog Pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -431,7 +414,6 @@ Y Axis = axis(1-,1+)
 [Win32: Colour Rumble Pad]
 [Jess Tech Colour Rumble Pad]
 plugged = True
-plugin = 1
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -456,7 +438,6 @@ Y Axis = axis(1-,1+)
 
 [Jess Tech USB 4-Axis 12-Button Gamepad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -481,7 +462,6 @@ Y Axis = axis(1-,1+)
 
 [Jess Technology Co., Ltd. USB Game Controllers]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -509,7 +489,6 @@ Y Axis = axis(1-,1+)
 [Logic3 Controller]
 [HORIPAD ONE]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -537,7 +516,6 @@ Y Axis = axis(1-,1+)
 [Logitech RumblePad 2 USB]
 [Logitech Dual Action]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -562,7 +540,6 @@ Y Axis = axis(1-,1+)
 
 [Logitech Gamepad F310]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -587,7 +564,6 @@ Y Axis = axis(1-,1+)
 
 [Logitech Gamepad F710]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -613,7 +589,6 @@ Y Axis = axis(1-,1+)
 [Logitech Logitech(R) Precision(TM) Gamepad]
 [Gravis GamePad Pro USB]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 100,100
 AnalogPeak = 32768,32768
@@ -639,7 +614,6 @@ Y Axis = axis(1-,1+)
 [Logitech WingMan Action Pad]
 [Logitech Inc WingMan RumblePad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -667,7 +641,6 @@ Y Axis = axis(1-,1+)
 ; this is a 4-port USB device. The ports from left to right are p1, p2, p3, p4.
 ; This is configured for Toki no Ocarina, therefore the L trig represents the Z trig and vice versa
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 128,128
 AnalogPeak = 28000,28000
@@ -693,7 +666,6 @@ X Axis = axis(4-,4+)
 
 [Mega World Thrustmaster dual analog 3.2]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -718,7 +690,6 @@ Y Axis = axis(1-,1+)
 
 [Mega World USB Game Controllers]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -743,7 +714,6 @@ Y Axis = axis(1-,1+)
 
 [MP-8866 Dual USB Joypad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -772,7 +742,6 @@ X Axis = axis(0-,0+)
 [Bluetooth Wireless Controller   ]
 [8Bitdo NES30 Pro]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -797,7 +766,6 @@ Y Axis = axis(1-,1+)
 
 [Linux: Xbox 360 Wireless Receiver (XBOX)]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -830,7 +798,6 @@ Y Axis = axis(1-,1+)
 [Afterglow Gamepad for Xbox 360]
 [Controller (Xbox One For Windows)]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -856,7 +823,6 @@ Y Axis = axis(1-,1+)
 # mappings for use with the TattieBogle driver under OSX, given in googlecode.com issue #630
 [OSX: Wireless 360 Controller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -882,7 +848,6 @@ Y Axis = axis(1-,1+)
 # from the Google Group, with the tattiebogle driver 0.15 beta 3 under El Capitan 10.11.1
 [OSX: Xbox 360 Wired Controller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -909,7 +874,6 @@ Y Axis = axis(1-,1+)
 ; various brands (e.g. techsolo TG-30)
 [USB GAMEPAD 8116]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -939,7 +903,6 @@ Y Axis = axis(1-,1+)
 [XInput: Xbox 360 Wireless Receiver]
 [XInput: XInput Controller #]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -965,7 +928,6 @@ Y Axis = axis(1-,1+)
 ;Snakebyte PS3-style USB controller
 [MY-POWER CO.,LTD. 2In1 USB Joystick]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -990,7 +952,6 @@ Y Axis = axis(1-,1+)
 
 [N64 controller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1015,7 +976,6 @@ Y Axis = axis(1-,1+)
 
 [Nintendo Wiimote Classic]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1040,7 +1000,6 @@ Y Axis = axis(5-,5+)
 
 [Nintendo Wii Remote Pro Controller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 2000,2000
 AnalogPeak = 17000,17000
@@ -1065,7 +1024,6 @@ Y Axis = axis(1-,1+)
 
 [OUYA Game Controller]
 plugged = True
-plugin = 2
 mouse = False
 Mempak switch =
 Rumblepak switch =
@@ -1088,7 +1046,6 @@ Y Axis = axis(1-,1+)
 
 [PC Game Controller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1114,7 +1071,6 @@ Y Axis = axis(1-,1+)
 ; Playfect PS3 controller (cheap clone of the Sony DualShock 3 controller)
 [PS3/PC WirelessGamePad]
 plugged = True
-plugin = 2
 mouse = False
 DPad R = hat(0 Right)
 DPad L = hat(0 Left)
@@ -1138,7 +1094,6 @@ Y Axis = axis(1-,1+)
 ; this is also the MayFlash / HuiJia adapter
 [PS/SS/N64 Joypad to USB BOX]
 plugged=True
-plugin=2
 mouse=False
 AnalogDeadzone=1024,1024
 AnalogPeak=11000,11000
@@ -1161,7 +1116,6 @@ Y Axis=axis(1-,1+)
 
 [Rock Candy Gamepad for PS3]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1188,7 +1142,6 @@ Y Axis = axis(1-,1+)
 [Sony PLAYSTATION(R)3 Controller]
 [SHENGHIC 2009/0708ZXW-V1Inc. PLAYSTATION(R)3Conteroller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1214,7 +1167,6 @@ Y Axis = axis(1-,1+)
 [Sony Computer Entertainment Wireless Controller]
 [Sony Interactive Entertainment Wireless Controller]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1239,7 +1191,6 @@ Y Axis = axis(1-,1+)
 
 [SAITEK P880]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1264,7 +1215,6 @@ Y Axis = axis(1-,1+)
 
 [Saitek P990 Dual Analog Pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1289,7 +1239,6 @@ Y Axis = axis(1-,1+)
 
 [Saitek P2900 Wireless Pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1314,7 +1263,6 @@ Y Axis = axis(1-,1+)
 
 [Saitek PLC Cyborg Force Rumble Pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1339,7 +1287,6 @@ Y Axis = axis(1-,1+)
 
 [ShanWan USB WirelessGamepad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1364,7 +1311,6 @@ X Axis = axis(0-,0+)
 
 [SZMY-POWER CO.,LTD. GAMEPAD 3 TURBO]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1389,7 +1335,6 @@ Y Axis = axis(1-,1+)
 
 [Thrustmaster Dual Trigger 3-in-1]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1414,7 +1359,6 @@ Y Axis = axis(1-,1+)
 
 [THRUSTMASTER Firestorm Dual Power 2]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1439,7 +1383,6 @@ Y Axis = axis(1-,1+)
 
 [Thrustmaster T Mini Wireless]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1464,7 +1407,6 @@ Y Axis = axis(1-,1+)
 
 [Twin USB Joystick]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1489,7 +1431,6 @@ X Axis = axis(0-,0+)
 
 [Twin USB Vibration Gamepad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1516,7 +1457,6 @@ Y Axis = axis(1-,1+)
 ;The controller closest to the USB-plug is Player 1.
 [Twin USB Gamepad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1541,7 +1481,6 @@ X Axis = axis(0-,0+)
 
 [Wii U GameCube Adapter Port 1]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1566,7 +1505,6 @@ Y Axis = axis(1-,1+)
 
 [WiseGroup.,Ltd TigerGame XBOX+PS2+GC Game Controller Adapter]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1592,7 +1530,6 @@ Y Axis = axis(1-,1+)
 [Wish Technologies Adaptoid]
 [Adaptoid]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1645,7 +1582,6 @@ Y Axis = axis(1-,1+)
 [Chinese-made Xbox Controller]
 [Generic X-Box pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1673,7 +1609,6 @@ Y Axis = axis(1-,1+)
 ; this is the "MayFlash" adapter, aka HuiJia.  The OSX driver seems to have a
 ; different button mapping
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 2500,2500
 AnalogPeak = 20000,20000
@@ -1697,7 +1632,6 @@ X Axis = axis(2-,2+)
 Y Axis = axis(3-,3+)
 __NextController:
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 2500,2500
 AnalogPeak = 20000,20000
@@ -1722,7 +1656,6 @@ Y Axis = axis(7-,7+)
 
 [Linux: HuiJia USB GamePad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 100,100
 AnalogPeak = 20000,20000
@@ -1746,7 +1679,6 @@ X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 __NextController:
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 100,100
 AnalogPeak = 20000,20000
@@ -1773,7 +1705,6 @@ Y Axis = axis(5-,5+)
 ; this is a 2-port USB device. The Right port is controller #1, the Left port is #2
 [Win32: USB GamePad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 1024,1024
 AnalogPeak = 12288,12288
@@ -1799,7 +1730,6 @@ X Axis = axis(0-,0+)
 ; MayFlash PC048 adapter
 [PS/SS/N64 Joypad to USB BOX]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 1024,1024
 AnalogPeak = 32768,32768
@@ -1826,7 +1756,6 @@ X Axis = axis(0-,0+)
 ; this is a 2-port USB device. The Right port is controller #1, the Left port is #2
 [USB Human(2p) Interface Device]
 plugged = True
-plugin = 2
 mouse = False
 DPad R= axis(2+)
 DPad L= axis(2-)
@@ -1848,7 +1777,6 @@ Y Axis= axis(1-,1+)
 X Axis= axis(0-,0+)
 __NextController:
 plugged = True
-plugin = 2
 mouse = False
 DPad R= axis(6+)
 DPad L= axis(6-)
@@ -1871,7 +1799,6 @@ X Axis= axis(3-,3+)
 
 [Microsoft SideWinder Game Pad Pro USB version 1.0]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1897,7 +1824,6 @@ Y Axis = axis(1-,1+)
 [USB,2-axis 8-button gamepad]
 [USB Gamepad ]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1923,7 +1849,6 @@ X Axis = axis(0-,0+)
 ; RetroUSB "USB N64 RetroPort"
 [N64 ]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 2048,2048
 AnalogPeak = 18432,18432
@@ -1948,7 +1873,6 @@ Y Axis = axis(1-,1+)
 
 [Jess Tech GGE909 PC Recoil Pad]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 4096,4096
 AnalogPeak = 32768,32768
@@ -1973,7 +1897,6 @@ Y Axis = axis(1-,1+)
 
 [8BITDO NES30]
 plugged = True
-plugin = 2
 mouse = False
 DPad R = key(3)
 DPad L = key(2)
@@ -1997,7 +1920,6 @@ Y Axis = key(273,274)
 ; Xiaomi Bluetooth Controller
 [小米蓝牙手柄]
 plugged = True
-plugin = 2
 mouse = False
 AnalogDeadzone = 0,0
 AnalogPeak = 32768,32768

--- a/src/autoconfig.c
+++ b/src/autoconfig.c
@@ -309,7 +309,7 @@ int auto_set_defaults(int iDeviceIdx, const char *joySDLName)
             *pivot++ = 0;
             pchCurLine = StripSpace(pchCurLine);
             pivot = StripSpace(pivot);
-            if (strcasecmp(pchCurLine, "plugin") == 0 || strcasecmp(pchCurLine, "device") == 0)
+            if (strcasecmp(pchCurLine, "device") == 0)
             {
                 int iVal = atoi(pivot);
                 ConfigSetParameter(pConfig, pchCurLine, M64TYPE_INT, &iVal);

--- a/src/config.c
+++ b/src/config.c
@@ -89,7 +89,7 @@ static void clear_controller(int iCtrlIdx)
     controller[iCtrlIdx].device = DEVICE_NO_JOYSTICK;
     controller[iCtrlIdx].control->Present = 0;
     controller[iCtrlIdx].control->RawData = 0;
-    controller[iCtrlIdx].control->Plugin = PLUGIN_NONE;
+    controller[iCtrlIdx].control->Plugin = PLUGIN_MEMPAK;
     for( b = 0; b < 16; b++ )
     {
         controller[iCtrlIdx].button[b].button = -1;
@@ -197,16 +197,11 @@ static int load_controller_config(const char *SectionName, int i, int sdlDeviceI
     /* set SDL device number */
     controller[i].device = sdlDeviceIdx;
 
-    /* throw warnings if 'plugged' or 'plugin' are missing */
+    /* throw warnings if 'plugged' is missing */
     if (ConfigGetParameter(pConfig, "plugged", M64TYPE_BOOL, &controller[i].control->Present, sizeof(int)) != M64ERR_SUCCESS)
     {
         DebugMessage(M64MSG_WARNING, "missing 'plugged' parameter from config section %s. Setting to 1 (true).", SectionName);
         controller[i].control->Present = 1;
-    }
-    if (ConfigGetParameter(pConfig, "plugin", M64TYPE_INT, &controller[i].control->Plugin, sizeof(int)) != M64ERR_SUCCESS)
-    {
-        DebugMessage(M64MSG_WARNING, "missing 'plugin' parameter from config section %s. Setting to 1 (none).", SectionName);
-        controller[i].control->Plugin = PLUGIN_NONE;
     }
     /* load optional parameters */
     ConfigGetParameter(pConfig, "mouse", M64TYPE_BOOL, &controller[i].mouse, sizeof(int));
@@ -334,7 +329,7 @@ static void init_controller_config(int iCtrlIdx, const char *pccDeviceName, eMod
     ConfigSetDefaultInt(pConfig, "device", controller[iCtrlIdx].device, "Specifies which joystick is bound to this controller: -1=No joystick, 0 or more= SDL Joystick number");
     ConfigSetDefaultString(pConfig, "name", pccDeviceName, "SDL joystick name (or Keyboard)");
     ConfigSetDefaultBool(pConfig, "plugged", controller[iCtrlIdx].control->Present, "Specifies whether this controller is 'plugged in' to the simulated N64");
-    ConfigSetDefaultInt(pConfig, "plugin", controller[iCtrlIdx].control->Plugin, "Specifies which type of expansion pak is in the controller: 1=None, 2=Mem pak, 5=Rumble pak");
+    ConfigSetDefaultInt(pConfig, "plugin", controller[iCtrlIdx].control->Plugin, "Specifies which type of expansion pak is in the controller: 1=None, 2=Mem pak, 4=Transfer pak, 5=Rumble pak");
     ConfigSetDefaultBool(pConfig, "mouse", controller[iCtrlIdx].mouse, "If True, then mouse buttons may be used with this controller");
 
     sprintf(Param, "%.2f,%.2f", controller[iCtrlIdx].mouse_sens[0], controller[iCtrlIdx].mouse_sens[1]);
@@ -605,6 +600,11 @@ void load_configuration(int bPreConfig)
             if (ConfigGetParameter(pConfig, "name", M64TYPE_STRING, DeviceName[n64CtrlIdx], 256) != M64ERR_SUCCESS)
             {
                 DeviceName[n64CtrlIdx][0] = 0;
+            }
+            if (ConfigGetParameter(pConfig, "plugin", M64TYPE_INT, &controller[n64CtrlIdx].control->Plugin, sizeof(int)) != M64ERR_SUCCESS)
+            {
+                DebugMessage(M64MSG_WARNING, "missing 'plugin' parameter from config section %s. Setting to 2 (mempak).", SectionName);
+                controller[n64CtrlIdx].control->Plugin = PLUGIN_MEMPAK;
             }
         }
     }


### PR DESCRIPTION
This adds supports for ```GetGBCartInfo```. See https://github.com/mupen64plus/mupen64plus-core/pull/337

It also removes the ```plugin``` setting from autoconfig. Right now, if you are using autoconfig, your "plugin" choice is set by the INI file, it shouldn't really be tied to that. So I removed it from the autoconfig settings