### PR TITLE
Re-attach joystick if it has disconnected

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -513,6 +513,19 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
     doSdlKeys(SDL_GetKeyboardState(NULL));
     doSdlKeys(myKeyState);
 
+    for ( b = 0; b < 4; ++b )
+    {
+        if (controller[b].device >= 0)
+        {
+#if SDL_VERSION_ATLEAST(2,0,0)
+            if (!SDL_JoystickGetAttached(controller[b].joystick))
+#else
+            if (!SDL_JoystickOpened(controller[b].device))
+#endif
+                controller[b].joystick = SDL_JoystickOpen(controller[b].device);
+        }
+    }
+    
     // read joystick state
     SDL_JoystickUpdate();
 


### PR DESCRIPTION
Right now, if a USB controller is disconnected during gameplay, it won't ever reconnect. This makes sure that all the controllers are connected using SDL_JoystickGetAttached/SDL_JoystickOpened, if it finds one that is not connected, it attempts to reconnect it.

@richard42 @bsmiles32 