### PR TITLE
Fix Microsoft X-Box 360 pad for Linux

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -764,6 +764,7 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+[Linux: Microsoft X-Box 360 pad]
 [Linux: Xbox 360 Wireless Receiver (XBOX)]
 plugged = True
 mouse = False
@@ -777,11 +778,11 @@ Start = button(7)
 Z Trig = axis(2+)
 B Button = button(2)
 A Button = button(0)
-C Button R = axis(3+)
-C Button L = axis(3-) button(3)
-C Button D = axis(4+) button(1)
-C Button U = axis(4-)
-R Trig = button(5) axis(5+)
+C Button R = axis(3+,24000)
+C Button L = axis(3-,24000) button(3)
+C Button D = axis(4+,24000) button(1)
+C Button U = axis(4-,24000)
+R Trig = button(5)
 L Trig = button(4)
 Mempak switch =
 Rumblepak switch =


### PR DESCRIPTION
This work best on my distro (Ubuntu 16.04.3 LTS).

The deadzone is very handy for Zelda games, the extra C buttons are indispensable to control Kirby and Jigglypuff in SSB64.
RT (`axis(5+)`) since always been broken, and interrupt LT (`axis(2+)`)... "There can be only one" (Highlander style =P)