### PR TITLE
Increase deadzone for axis->N64 button mappings

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -542,7 +542,7 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
                 int deadzone = controller[Control].button[b].axis_deadzone;
                 axis_val = SDL_JoystickGetAxis( controller[Control].joystick, controller[Control].button[b].axis );
                 if (deadzone < 0)
-                    deadzone = 6000; /* default */
+                    deadzone = 16384; /* default */
                 if( (controller[Control].button[b].axis_dir < 0) && (axis_val <= -deadzone) )
                     controller[Control].buttons.Value |= button_bits[b];
                 else if( (controller[Control].button[b].axis_dir > 0) && (axis_val >= deadzone) )


### PR DESCRIPTION
Right now the default deadzone when mapping an axis to an N64 button is 6000 (out of 32768). This is generally too sensitive. I often find myself pressing the wrong c-button when using the right analog stick for that function.

A deadzone of 16384 (50%) would be more appropriate for the function of a button