### PR TITLE
Added Multilaser Controller JS030

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -813,6 +813,32 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+; Multilaser PS2 Generic Controller JS030
+[Microntek              USB Joystick          ]
+[USB Network Joystick]
+plugged = True
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+Z Trig = button(6)
+B Button = button(3)
+A Button = button(2)
+C Button R = axis(2+)
+C Button L = axis(2-)
+C Button D = axis(3+)
+C Button U = axis(3-)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 [Microsoft X-Box 360 pad]
 [Microsoft X-Box One pad]
 [Win32: Controller (XBOX 360 For Windows)]


### PR DESCRIPTION
It is recognized as USB Network Joystick on Windows and as Microntek USB Joystick on Ubuntu

![js030_a](https://user-images.githubusercontent.com/10705488/35197585-25e6ddae-fec0-11e7-8a20-d06e6dc06470.jpg)
