### PR TITLE
added support for the Nintendo Switch Joy-Con 1

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -2045,3 +2045,28 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+[Full Joy-Con 1]
+plugged = True
+plugin = 2
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = button(16)
+DPad L = button(15)
+DPad D = button(14)
+DPad U = button(13)
+Start = button(9)
+Z Trig = button(11)
+B Button = button(3)
+A Button = button(2)
+C Button R = axis(4+)
+C Button L = axis(4-)
+C Button D = axis(5-)
+C Button U = axis(5+)
+R Trig = button(7)
+L Trig = button(6)
+Mempak switch = button(4)
+Rumblepak switch = button(5)
+X Axis = axis(2+, 2-)
+Y Axis = axis(3+, 3-)
+


### PR DESCRIPTION
I neglected to add a configuration for the each of the single joycon controlers "Left and Right" since they don't have enough input buttons to fully emulate the n64 inputs of an N64 controler and would have very few use cases. This input profile assumes you're using [this joycon driver](https://github.com/riking/joycon)