### PR TITLE
Added an optional CMake build for mupen64plus-input-sdl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /projects/unix/_obj*/
 /projects/unix/mupen64plus-input-sdl*.so
+/build/

--- a/CMake/Find/FindSDL2.cmake
+++ b/CMake/Find/FindSDL2.cmake
@@ -1,0 +1,169 @@
+
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+message("<FindSDL2.cmake>")
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+	${SDL2_PATH}
+)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES include/SDL2 include
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+	NAMES SDL2
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES lib64 lib
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+		# Non-OS X framework versions expect you to also dynamically link to
+		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+		# seem to provide SDL2main for compatibility even though they don't
+		# necessarily need it.
+		FIND_LIBRARY(SDL2MAIN_LIBRARY
+			NAMES SDL2main
+			HINTS
+			$ENV{SDL2DIR}
+			PATH_SUFFIXES lib64 lib
+			PATHS ${SDL2_SEARCH_PATHS}
+		)
+	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+	FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+	SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+IF(SDL2_LIBRARY_TEMP)
+	# For SDL2main
+	IF(NOT SDL2_BUILDING_LIBRARY)
+		IF(SDL2MAIN_LIBRARY)
+			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+		ENDIF(SDL2MAIN_LIBRARY)
+	ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+	# CMake doesn't display the -framework Cocoa string in the UI even
+	# though it actually is there if I modify a pre-used variable.
+	# I think it has something to do with the CACHE STRING.
+	# So I use a temporary variable until the end so I can set the
+	# "real" variable in one-shot.
+	IF(APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+	ENDIF(APPLE)
+
+	# For threads, as mentioned Apple doesn't need this.
+	# In fact, there seems to be a problem if I used the Threads package
+	# and try using this line, so I'm just skipping it entirely for OS X.
+	IF(NOT APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+	ENDIF(NOT APPLE)
+
+	# For MinGW library
+	IF(MINGW)
+		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+	ENDIF(MINGW)
+
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+message("</FindSDL2.cmake>")
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,111 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(mupen64plus-input-sdl)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(M64_APIDIR "${CMAKE_SOURCE_DIR}/../mupen64plus-core/src/api")
+option(UseOnScreenDisplay "UseOnScreenDisplay" ON)
+
+# State directories for modules and binaries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake)
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Find)
+
+#Making the compiler as strict as possible
+#set(CMAKE_CXX_FLAGS "-std=c++14 -fno-elide-constructors -pedantic-errors -Werror -Wextra -Wall -Wpedantic -Winit-self -Wmissing-declarations -Wuninitialized -Woverloaded-virtual -Wold-style-cast -Wfatal-errors -O3 -ldl -pthread")
+set(CMAKE_CC_FLAGS "-ffast-math -fno-strict-aliasing -fvisibility=hidden -D_GNU_SOURCE=1")
+
+set(CMAKE_CXX_FLAGS "-pthread -fvisibility-inlines-hidden")
+#add_definitions(${CMAKE_CXX_FLAGS})
+#add_definitions(${CMAKE_CC_FLAGS})
+
+#Location of source filesfind_package(SDL2 REQUIRED)
+#file(GLOB SOURCE src/*.cpp src/*.hpp)
+
+set(SRCS
+  src/autoconfig.c
+  src/config.c
+  src/plugin.c
+  src/sdl_key_converter.c
+  )
+
+if(WIN32)
+  set(SRCS
+    ${SRCS}
+    src/osal_dynamiclib_win32.c
+    )
+else()
+  set(SRCS
+    ${SRCS}
+    src/osal_dynamiclib_unix.c
+    )
+endif()
+
+# Find dependencies
+find_package(PNG REQUIRED)
+if(NOT ZLIB_FOUND)
+    include(ZLIB)
+    message(FATAL_ERROR "Package zlib is required, but not found!")
+endif(NOT ZLIB_FOUND)
+
+find_package(PNG REQUIRED)
+if(NOT PNG_FOUND)
+    include(PNG)
+    message(FATAL_ERROR "Package libpng is required, but not found!")
+endif(NOT PNG_FOUND)
+
+find_package(SDL2 REQUIRED)
+if(NOT SDL2_FOUND)
+    include(SDL2)
+    message(FATAL_ERROR "Package SDL2 is required, but not found!")
+endif(NOT SDL2_FOUND)
+
+find_package(OpenGL REQUIRED)
+if(NOT OpenGL_FOUND)
+    message(FATAL_ERROR "Package OpenGL is required, but not found!")
+endif(NOT OpenGL_FOUND)
+
+find_package(Freetype REQUIRED)
+if(NOT FREETYPE_FOUND)
+    message(FATAL_ERROR "Package FreeType is required, but not found!")
+endif(NOT FREETYPE_FOUND)
+
+# Specify include directories
+include_directories(
+  ${PNG_INCLUDE_DIR}
+  ${OpenGL_INCLUDE_DIR}
+  ${SDL2_INCLUDE_DIR}
+  ${FREETYPE_INCLUDE_DIR_ft2build}
+  ${FREETYPE_INCLUDE_DIR_freetype2}
+  ${M64_APIDIR}
+  src/
+  )
+# Create the binary
+add_library(${CMAKE_PROJECT_NAME} SHARED ${SRCS})
+
+# Link the libraries
+# add_dependencies(${CMAKE_PROJECT_NAME} ${SDL2_LIBRARIES})
+
+if(WIN32)
+  target_link_libraries(${CMAKE_PROJECT_NAME}
+    ${PNG_LIBRARY}
+    ${OPENGL_LIBRARIES}
+    ${SDL2_LIBRARY}
+    ${ZLIB_LIBRARY}
+    )
+elseif(APPLE)
+  target_link_libraries(${CMAKE_PROJECT_NAME}
+    ${PNG_LIBRARY}
+    ${OPENGL_LIBRARIES}
+    ${SDL2_LIBRARY}
+    ${ZLIB_LIBRARY}
+    )
+else()
+  target_link_libraries(${CMAKE_PROJECT_NAME}
+    ${PNG_LIBRARY}
+    ${OPENGL_LIBRARIES}
+    ${SDL2_LIBRARY}
+    ${ZLIB_LIBRARY}
+    ${FREETYPE_LIBRARIES}
+    dl
+    )
+endif()


### PR DESCRIPTION
I created a CMake build for this module of mupen64plus, I'd like to see about porting the rest of the project to CMake as well.