### PR TITLE
Recognise DS4 controllers in Bluetooth mode

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1292,6 +1292,7 @@ Y Axis = axis(1-,1+)
 
 [Sony Computer Entertainment Wireless Controller]
 [Sony Interactive Entertainment Wireless Controller]
+[Wireless Controller]
 plugged = True
 mouse = False
 AnalogDeadzone = 4096,4096

--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1292,7 +1292,6 @@ Y Axis = axis(1-,1+)
 
 [Sony Computer Entertainment Wireless Controller]
 [Sony Interactive Entertainment Wireless Controller]
-[Wireless Controller]
 plugged = True
 mouse = False
 AnalogDeadzone = 4096,4096
@@ -1309,6 +1308,32 @@ C Button R = axis(2+)
 C Button L = axis(2-)
 C Button D = axis(5+)
 C Button U = axis(5-)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
+; Sony DS4 connected via Bluetooth advertises itself as "Wireless Controller"
+[Wireless Controller]
+plugged = True
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+; L2, change to 7 for R2
+Z Trig = button(6)
+B Button = button(0)
+A Button = button(1)
+C Button R = axis(3+)
+C Button L = axis(3-)
+C Button D = axis(4+)
+C Button U = axis(4-)
 R Trig = button(5)
 L Trig = button(4)
 Mempak switch =


### PR DESCRIPTION
Legit DS4 controllers advertise themselves as Wireless Controller when connected via Bluetooth.
sony 0005:054C:05C4.0043: input,hidraw4: BLUETOOTH HID v81.00 Gamepad [Wireless Controller] on b0:25:9f:d3:8b:d8