### PR TITLE
Remove use of ConfigSaveSection

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -449,7 +449,6 @@ static int setup_auto_controllers(int bPreConfig, int n64CtrlStart, int sdlCtrlI
         if (!bPreConfig)
             DebugMessage(M64MSG_INFO, "N64 Controller #%i: Using auto-config with SDL joystick %i ('%s')", n64CtrlStart+1, sdlCtrlIdx, sdlJoyName);
         ActiveControllers++;
-        ConfigSaveSection(SectionName);
     }
     else
     {
@@ -487,7 +486,6 @@ static int setup_auto_controllers(int bPreConfig, int n64CtrlStart, int sdlCtrlI
                     if (!bPreConfig)
                         DebugMessage(M64MSG_INFO, "N64 Controller #%i: Using auto-config with SDL joystick %i ('%s')", n64CtrlStart+j+1, sdlCtrlIdx, sdlJoyName);
                     ActiveControllers++;
-                    ConfigSaveSection(SectionName);
                     /* set the local controller mode to Manual so that we won't re-configure this controller in the next loop */
                     ControlMode[n64CtrlStart+j] = E_MODE_MANUAL;
                 }
@@ -578,8 +576,6 @@ void load_configuration(int bPreConfig)
             DeviceName[n64CtrlIdx][0] = 0;
             // write blank config for GUI front-ends
             init_controller_config(n64CtrlIdx, "", E_MODE_FULL_AUTO);
-            // save it to the file too
-            ConfigSaveSection(SectionName);
         }
         else
         {
@@ -655,7 +651,6 @@ void load_configuration(int bPreConfig)
                 /* copy the auto-config settings to the controller config section */
                 auto_copy_inputconfig("AutoConfig0", SectionName, "Keyboard");
                 ActiveControllers++;
-                ConfigSaveSection(SectionName);
             }
             else
             {
@@ -752,7 +747,6 @@ void load_configuration(int bPreConfig)
                 ConfigSetParameter(section, "device", M64TYPE_INT, &iNoDevice);
                 if (OrigControlMode[n64CtrlIdx] == E_MODE_FULL_AUTO)
                     ConfigSetParameter(section, "name", M64TYPE_STRING, "");
-                ConfigSaveSection(SectionName);
             }
         }
     }
@@ -771,7 +765,6 @@ void load_configuration(int bPreConfig)
             else
                 auto_copy_inputconfig("AutoConfig0", "Input-SDL-Control1", NULL);  // don't overwrite 'name' parameter
             ActiveControllers++;
-            ConfigSaveSection("Input-SDL-Control1");
         }
         else
         {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -60,9 +60,7 @@
 /* definitions of pointers to Core config functions */
 ptr_ConfigOpenSection      ConfigOpenSection = NULL;
 ptr_ConfigDeleteSection    ConfigDeleteSection = NULL;
-ptr_ConfigSaveSection      ConfigSaveSection = NULL;
 ptr_ConfigListParameters   ConfigListParameters = NULL;
-ptr_ConfigSaveFile         ConfigSaveFile = NULL;
 ptr_ConfigSetParameter     ConfigSetParameter = NULL;
 ptr_ConfigGetParameter     ConfigGetParameter = NULL;
 ptr_ConfigGetParameterHelp ConfigGetParameterHelp = NULL;
@@ -170,8 +168,6 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
     /* Get the core config function pointers from the library handle */
     ConfigOpenSection = (ptr_ConfigOpenSection) osal_dynlib_getproc(CoreLibHandle, "ConfigOpenSection");
     ConfigDeleteSection = (ptr_ConfigDeleteSection) osal_dynlib_getproc(CoreLibHandle, "ConfigDeleteSection");
-    ConfigSaveFile = (ptr_ConfigSaveFile) osal_dynlib_getproc(CoreLibHandle, "ConfigSaveFile");
-    ConfigSaveSection = (ptr_ConfigSaveSection) osal_dynlib_getproc(CoreLibHandle, "ConfigSaveSection");
     ConfigListParameters = (ptr_ConfigListParameters) osal_dynlib_getproc(CoreLibHandle, "ConfigListParameters");
     ConfigSetParameter = (ptr_ConfigSetParameter) osal_dynlib_getproc(CoreLibHandle, "ConfigSetParameter");
     ConfigGetParameter = (ptr_ConfigGetParameter) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParameter");
@@ -189,7 +185,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
     ConfigGetUserDataPath = (ptr_ConfigGetUserDataPath) osal_dynlib_getproc(CoreLibHandle, "ConfigGetUserDataPath");
     ConfigGetUserCachePath = (ptr_ConfigGetUserCachePath) osal_dynlib_getproc(CoreLibHandle, "ConfigGetUserCachePath");
 
-    if (!ConfigOpenSection || !ConfigDeleteSection || !ConfigSaveFile || !ConfigSaveSection || !ConfigSetParameter || !ConfigGetParameter ||
+    if (!ConfigOpenSection || !ConfigDeleteSection || !ConfigSetParameter || !ConfigGetParameter ||
         !ConfigSetDefaultInt || !ConfigSetDefaultFloat || !ConfigSetDefaultBool || !ConfigSetDefaultString ||
         !ConfigGetParamInt   || !ConfigGetParamFloat   || !ConfigGetParamBool   || !ConfigGetParamString ||
         !ConfigGetSharedDataFilepath || !ConfigGetUserConfigPath || !ConfigGetUserDataPath || !ConfigGetUserCachePath)

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -158,8 +158,6 @@ extern ptr_ConfigListSections     ConfigListSections;
 extern ptr_ConfigOpenSection      ConfigOpenSection;
 extern ptr_ConfigDeleteSection    ConfigDeleteSection;
 extern ptr_ConfigListParameters   ConfigListParameters;
-extern ptr_ConfigSaveFile         ConfigSaveFile;
-extern ptr_ConfigSaveSection      ConfigSaveSection;
 extern ptr_ConfigSetParameter     ConfigSetParameter;
 extern ptr_ConfigGetParameter     ConfigGetParameter;
 extern ptr_ConfigGetParameterHelp ConfigGetParameterHelp;


### PR DESCRIPTION
Known front-ends have been modified to save configuration after plugin
initialization but before running the game. Now it is no longer
necessary for individual plugins to save their config.

Removing calls to ConfigSaveSection from within plugins makes the
mupen64plus-ui-console '--nosaveoptions' parameter work.

Also remove unused reference to ConfigSaveFile.