### PR TITLE
Improve input-sdl startup time.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -121,15 +121,6 @@ static const char * get_sdl_joystick_name(int iCtrlIdx)
 {
     static char JoyName[256];
     const char *joySDLName;
-    int joyWasInit = SDL_WasInit(SDL_INIT_JOYSTICK);
-    
-    /* initialize the joystick subsystem if necessary */
-    if (!joyWasInit)
-        if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
-        {
-            DebugMessage(M64MSG_ERROR, "Couldn't init SDL joystick subsystem: %s", SDL_GetError() );
-            return NULL;
-        }
 
     /* get the name of the corresponding joystick */
     joySDLName = SDL_JoystickName(iCtrlIdx);
@@ -141,38 +132,11 @@ static const char * get_sdl_joystick_name(int iCtrlIdx)
         JoyName[255] = 0;
     }
 
-    /* quit the joystick subsystem if necessary */
-    if (!joyWasInit)
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-
     /* if the SDL function had an error, then return NULL, otherwise return local copy of joystick name */
     if (joySDLName == NULL)
         return NULL;
     else
         return JoyName;
-}
-
-static int get_sdl_num_joysticks(void)
-{
-    int numJoysticks = 0;
-    int joyWasInit = SDL_WasInit(SDL_INIT_JOYSTICK);
-    
-    /* initialize the joystick subsystem if necessary */
-    if (!joyWasInit)
-        if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) == -1)
-        {
-            DebugMessage(M64MSG_ERROR, "Couldn't init SDL joystick subsystem: %s", SDL_GetError() );
-            return 0;
-        }
-
-    /* get thenumber of joysticks */
-    numJoysticks = SDL_NumJoysticks();
-
-    /* quit the joystick subsystem if necessary */
-    if (!joyWasInit)
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-
-    return numJoysticks;
 }
 
 /////////////////////////////////////
@@ -540,7 +504,7 @@ void load_configuration(int bPreConfig)
     int ControlDevice[4];
     char DeviceName[4][256];
     int ActiveControllers = 0;
-    int sdlNumJoysticks = get_sdl_num_joysticks();
+    int sdlNumJoysticks = SDL_NumJoysticks();
     float fVersion = 0.0f;
     const char *sdl_name;
     int ControllersFound = 0;


### PR DESCRIPTION
SDL_InitSubSystem() takes approximately 0.6s for me, presumably because
it does lots of device enumeration.

When all Input-sdl-ControlX configuration sections are present and
valid, then input-sdl calls SDL_InitSubSystem(SDL_INIT_JOYSTICK) three
times. When configuration is not present, this happens once more for
each connected joysick.

Moving the SDL_InitSubSystem(SDL_INIT_JOYSTICK) calls to a higher level
allows for a reduction to two total calls (whether configuration is
present or not). The first remaining call happens when loading the
plugin and the second call happens when attaching the plugin to the
core. Keeping these calls separate allows SDL to refresh itself in case
the user has plugged/unplugged a joystick in between (not likely with
ui-console, but perhaps with a GUI).

On a system with three joystick devices, loading a game and then
exiting (--testshots 0), this reduces time by:
with configuration:    11.5%
without configuration: 32.1%

Full benchmarks:

[ ----------- original behavior -------------]
[ with configuraton ][ without configuration ]
real    0m5.255s        real    0m7.470s
user    0m1.499s        user    0m1.534s
sys     0m0.110s        sys     0m0.135s

real    0m5.313s        real    0m7.471s
user    0m1.471s        user    0m1.514s
sys     0m0.119s        sys     0m0.120s

real    0m5.360s        real    0m7.414s
user    0m1.496s        user    0m1.569s
sys     0m0.106s        sys     0m0.127s

[ ------------ patched behavior -------------]
[ with configuraton ][ without configuration ]
real    0m4.741s        real    0m5.088s
user    0m1.473s        user    0m1.468s
sys     0m0.122s        sys     0m0.101s

real    0m4.724s        real    0m5.066s
user    0m1.511s        user    0m1.484s
sys     0m0.082s        sys     0m0.090s

real    0m4.628s        real    0m5.024s
user    0m1.494s        user    0m1.504s
sys     0m0.094s        sys     0m0.081s