### PR TITLE
add tested autoconfig for "Controller (XEOX Gamepad)"

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -873,6 +873,7 @@ Y Axis = axis(1-,1+)
 [Linux: Xbox Gamepad (userspace driver)]
 [Afterglow Gamepad for Xbox 360]
 [Controller (Xbox One For Windows)]
+[Controller (XEOX Gamepad)]
 plugged = True
 mouse = False
 AnalogDeadzone = 4096,4096


### PR DESCRIPTION
This is a controller I own (https://www.x-kom.pl/p/425872-pad-speedlink-xeox-pro-analog-gamepad-wireless-pc.html) I tested the configuration and it's working good.