### PR TITLE
Fixes for Nintendo Wii Remote Pro Controller autoconfig

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1102,8 +1102,8 @@ Y Axis = axis(5-,5+)
 [Nintendo Wii Remote Pro Controller]
 plugged = True
 mouse = False
-AnalogDeadzone = 2000,2000
-AnalogPeak = 17000,17000
+AnalogDeadzone = 3500,3500
+AnalogPeak = 22000,22000
 DPad R = button(16)
 DPad L = button(15)
 DPad D = button(14)
@@ -1118,8 +1118,8 @@ C Button D = axis(3+)
 C Button U = axis(3-)
 R Trig = button(5)
 L Trig = button(4)
-Mempak switch =
-Rumblepak switch =
+Mempak switch = button(2)
+Rumblepak switch = button(3)
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 


### PR DESCRIPTION
- Increase value of AnalogDeadzone by ~75%, because the stick felt too sensitive to me. 
- Increase value of AnalogPeak by ~55% otherwise it will go over the peak and then go in the opposite direction, thus making games unplayable.
- Assign X for Mempak switch and Y for Rumblepak switch, because why not?

Tested on Linux.