### PR TITLE
Fixed mouse_residual over/underflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 /projects/unix/_obj*/
 /projects/unix/mupen64plus-input-sdl*.so
 /build/
+/projects/VisualStudio2013/Release
+/projects/VisualStudio2013/Debug
+*.db
+*.opendb
+*.ipch
+*.obj
+*.tlog
+*.vcxproj.user

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -639,8 +639,8 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
             }
 
             /* store the result */
-            int iX = mousex_residual;
-            int iY = -mousey_residual;
+            int iX = min(127, max(mousex_residual, -127));
+            int iY = -min(127, max(mousey_residual, -127));
             controller[Control].buttons.X_AXIS = iX;
             controller[Control].buttons.Y_AXIS = iY;
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -653,10 +653,8 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
             /* the mouse x/y values decay exponentially (returns to center), unless the left "Windows" key is held down */
             if (!myKeyState[SDL_SCANCODE_LGUI])
             {
-                /*mousex_residual = (mousex_residual * 224) / 256;
-                mousey_residual = (mousey_residual * 224) / 256;*/
-				mousex_residual = 0;
-				mousey_residual = 0;
+                mousex_residual = (mousex_residual * 224) / 256;
+                mousey_residual = (mousey_residual * 224) / 256;
             }
         }
         else

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -115,6 +115,12 @@ static struct ff_effect ffstrong[4];
 static struct ff_effect ffweak[4];
 #endif //__linux__
 
+#ifndef min
+#define min(a,b) (((a) < (b)) ? (a) : (b))
+#define max(a,b) (((a) > (b)) ? (a) : (b))
+#endif // !min
+
+
 /* Global functions */
 void DebugMessage(int level, const char *message, ...)
 {
@@ -647,8 +653,10 @@ EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
             /* the mouse x/y values decay exponentially (returns to center), unless the left "Windows" key is held down */
             if (!myKeyState[SDL_SCANCODE_LGUI])
             {
-                mousex_residual = (mousex_residual * 224) / 256;
-                mousey_residual = (mousey_residual * 224) / 256;
+                /*mousex_residual = (mousex_residual * 224) / 256;
+                mousey_residual = (mousey_residual * 224) / 256;*/
+				mousex_residual = 0;
+				mousey_residual = 0;
             }
         }
         else


### PR DESCRIPTION
Realized this issue existed when trying to set up some controls for a FPS. The mousex_residual and mousey_residual values could go into the infinities. There are potentially better solutions than my quick fix.