### PR TITLE
Allow non-default compilers without resorting to symbolic links

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -182,8 +182,8 @@ endif
 endif
 
 # set base program pointers and flags
-CC        = $(CROSS_COMPILE)gcc
-CXX       = $(CROSS_COMPILE)g++
+CC       ?= $(CROSS_COMPILE)gcc
+CXX      ?= $(CROSS_COMPILE)g++
 RM       ?= rm -f
 INSTALL  ?= install
 MKDIR ?= mkdir -p


### PR DESCRIPTION
mupen64plus/mupen64plus-core#775