### PR TITLE
Add input config for Google Stadia controller.

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -2223,3 +2223,27 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+[Google LLC Stadia Controller]
+plugged = True
+plugin = 2
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(8)
+Z Trig = button(3)
+B Button = button(1)
+A Button = button(0)
+C Button R = axis(2+)
+C Button L = axis(2-)
+C Button D = axis(3+)
+C Button U = axis(3-)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)


### PR DESCRIPTION
This adds Google Stadia controller support to `InputAutoCfg`. I'd like feedback though on how I've defined buttons.

Here's what a Stadia controller looks like. It works as a normal HID joystick when plugged in via a USB-C (to USB-A in my case) cable. I'm testing on Linux, I'd be curious if this works correctly on Windows or Mac depending how the controller identifies.

![stadia-controller](https://user-images.githubusercontent.com/403277/113492124-8d87cf00-94a3-11eb-972c-5f652571002d.png)

First, the straight forward ones:
- The Dpad is mapped to the Dpad
- The center N64 analog stick is mapped to the left analog stick on the Stadia
- The C Button Dpad is mapped to the right analog stick on the Stadia
- Start is mapped to the center Stadia button
- The L and R shoulder triggers are mapped to the Left/Right bumper buttons on the Stadia

The ones I'm unsure of:
- I've mapped the `Z Trig` to the `Y` button (the top button on the right side) on the Stadia for lack of a better idea
- I've mapped `A` and `B` to the buttons labeled as `A` and `B` on the Stadia, though that flips where they are compared to a real N64 controller. I thought about reversing them, but decided to map them to the buttons they're labeled as to avoid confusion.

I've left the `X`, `Menu`, `Capture`, `Google Assistant`, and `Options` buttons unused, along with the Left and Right analog triggers. Maybe one of these would make more sense for the `Z Trig`?

I also don't know if the rumble of the Stadia can be controlled in some way by Mupen64, if that's what `Rumplepak switch` is intended for.

Once I get some feedback on any changes to the mapping, I'll add text to the README describing this controller like the others.