### PR TITLE
Add Xbox One Elite Controller to InputAutoCfg.ini

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1055,6 +1055,7 @@ Y Axis = axis(1-,1+)
 [XInput: Xbox 360 Wireless Receiver]
 [XInput: XInput Controller #]
 [Xbox One S Controller]
+[Xbox One Elite Controller]
 plugged = True
 mouse = False
 AnalogDeadzone = 4096,4096


### PR DESCRIPTION
I am actually not using an Elite Controller. It's what both my revised Xbox One and Series controllers are recognized as (plugged in via cable).