### PR TITLE
Sony PS4 Controller support for linux

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1399,6 +1399,30 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+[Linux: Sony Interactive Entertainment Wireless Controller]
+plugged = True
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+Z Trig = button(6)
+B Button = button(3)
+A Button = button(0)
+C Button R = axis(3+)
+C Button L = axis(3-)
+C Button D = axis(4+)
+C Button U = axis(4-)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 ; Sony DS4 connected via Bluetooth advertises itself as "Wireless Controller"
 [Wireless Controller]
 plugged = True


### PR DESCRIPTION
The [Sony Interactive Entertainment Wireless Controller] had incompatible bindings. Z was right analog stick up.
I made a list of the ps4 buttons:
button 0 = cross
button 1 = circle
button 2 = triangle
button 3 = square
button 4 = l1
button 5 = r1
button 6 = l2
button 7 = r2
button 8 = share
button 9 = options
button 10 = ps
button 11 = l3
button 12 = r3

axis 0- = lstick left
axis 0+ = lstick right
axis 1- = lstick up
axis 1+ = lstick down
axis 2+ = l2
axis 2- = l2
axis 3- = rstick left
axis 3+ = rstick right
axis 4- = rstick up
axis 4+ = rstick down
axis 5+ = r2
axis 5- = r2

hat 0 Right = Right
hat 0 Left = Left
hat 0 Down = Down
hat 0 Up = Up
