### PR TITLE
Add USB controller from PS1 Classic

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1348,6 +1348,31 @@ Rumblepak switch =
 X Axis = axis(0-,0+)
 Y Axis = axis(1-,1+)
 
+; Sony USB-Controller from PS1 Classic
+[Sony Interactive Entertainment Controller]
+plugged = True
+mouse = False
+AnalogDeadzone = 4096,4096
+AnalogPeak = 32768,32768
+DPad R = hat(0 Right)
+DPad L = hat(0 Left)
+DPad D = hat(0 Down)
+DPad U = hat(0 Up)
+Start = button(9)
+Z Trig = axis(3-)
+B Button = button(7)
+A Button = button(2)
+C Button R = button(1)
+C Button L = button(3)
+C Button D = button(6)
+C Button U = button(0)
+R Trig = button(5)
+L Trig = button(4)
+Mempak switch =
+Rumblepak switch =
+X Axis = axis(0-,0+)
+Y Axis = axis(1-,1+)
+
 [PLAYSTATION(R)3 Controller]
 [Sony PLAYSTATION(R)3 Controller]
 [SHENGHIC 2009/0708ZXW-V1Inc. PLAYSTATION(R)3Conteroller]


### PR DESCRIPTION
Limited support due to lacking stick (only 1 D-Pad there). Optimal settings to play Tony Hawk'y Pro Skater 2

![image](https://user-images.githubusercontent.com/1888714/165038159-501e69ca-822f-4b04-9245-ccc681e25b1e.png)
