### PR TITLE
Add support for "Xbox Series X Controller"

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1058,6 +1058,7 @@ Y Axis = axis(1-,1+)
 [XInput: XInput Controller #]
 [Xbox One S Controller]
 [Xbox One Elite Controller]
+[Xbox Series X Controller]
 plugged = True
 mouse = False
 AnalogDeadzone = 4096,4096


### PR DESCRIPTION
I was surprised to see mupen not able to auto-config this controller. This fixes that. All the inputs match and works great.