### PR TITLE
add Horipad controller for Nintendo Switch

### DIFF
--- a/data/InputAutoCfg.ini
+++ b/data/InputAutoCfg.ini
@@ -1252,6 +1252,8 @@ Y Axis = axis(1-,1+)
 
 ; Nintendo Switch Pro Controller
 [Pro Controller]
+[HORIPAD FPS for Nintendo Switch]
+[HORIPAD S]
 plugged = True
 mouse = False
 AnalogDeadzone = 4096,4096


### PR DESCRIPTION
HORIPAD for Nintendo Switch works well with the current Nintendo Switch Pro Controller configuration.

![horipad-nintendo-switch](https://github.com/user-attachments/assets/977ee6db-5d39-444f-92ea-de35ff366c65)
